### PR TITLE
added loose config

### DIFF
--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -177,6 +177,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -103,6 +103,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -177,6 +177,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -103,6 +103,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Loose config is necessary to make applications work with `mvn compile`