### PR TITLE
Mp open tracing 1.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -215,34 +215,16 @@ This feature is already configured for you in your `pom.xml` and `server.xml` fi
 downloaded and installed automatically into each service when you run a Maven build. You can find it
 enabled in your `server.xml` files:
 
-[source, xml, role="no_copy"]
+[source, xml, role="no_copy", indent=0]
 ----
-<feature>usr:opentracingZipkin-0.30</feature>
+include::finish/inventory/src/main/liberty/config/server.xml[tags=zipkinUsr]
 ----
 
 The following Maven plug-in is responsible for downloading and installing the feature:
 
-[source, xml, role="no_copy"]
+[source, xml, role="no_copy", indent=0]
 ----
-<plugin>
-    <groupId>com.googlecode.maven-download-plugin</groupId>
-    <artifactId>download-maven-plugin</artifactId>
-    <version>${version.download-maven-plugin}</version>
-    <executions>
-        <execution>
-            <id>install-tracer</id>
-            <phase>prepare-package</phase>
-            <goals>
-                <goal>wget</goal>
-            </goals>
-            <configuration>
-                <url>https://repo1.maven.org/maven2/net/wasdev/wlp/tracer/liberty-opentracing-zipkintracer/1.0/liberty-opentracing-zipkintracer-1.0-sample.zip</url>
-                <unpack>true</unpack>
-                <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
+include::finish/inventory/pom.xml[tags=download]
 ----
 
 If you want to install this feature yourself, see
@@ -256,7 +238,7 @@ in the IBM Knowledge Centre.
 
 == Enabling distributed tracing
 
-The `mpOpenTracing-1.0` MicroProfile OpenTracing feature enables tracing of all JAX-RS methods by default.
+The MicroProfile OpenTracing feature enables tracing of all JAX-RS methods by default.
 To further control and customize these traces, use the `@Traced` annotation to enable and disable
 tracing of particular methods. You can also inject a custom `Tracer` object to create and customize spans.
 
@@ -269,10 +251,9 @@ OpenTracing and the Zipkin user feature in the `server.xml` file to see some bas
 Both of these features are already enabled in the `inventory/src/main/liberty/config/server.xml`
 and `system/src/main/liberty/config/server.xml` files:
 
-[source, xml, role="no_copy"]
+[source, xml, role="no_copy", indent=0]
 ----
-<feature>mpOpenTracing-1.0</feature>
-<feature>usr:opentracingZipkin-0.30</feature>
+include::finish/inventory/src/main/liberty/config/server.xml[tags=zipkinUsr;mpOpenTracing]
 ----
 
 Make sure that your services are running. Then, simply point your browser to any of their endpoints and

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -164,12 +164,13 @@
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <assemblyArtifact>
+                    <!-- <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-runtime</artifactId>
                         <version>${version.openliberty-runtime}</version>
                         <type>zip</type>
-                    </assemblyArtifact>
+                    </assemblyArtifact> -->
+                    <assemblyArchive>/Users/dima/Downloads/openliberty-all-18.0.0.3-20180822-1616.zip</assemblyArchive>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <include>usr</include>
                     <bootstrapProperties>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -17,6 +17,7 @@
     </properties>
 
     <dependencies>
+        <!-- For tests -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -33,34 +34,38 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
         </dependency>
+        <!-- Open Liberty features -->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>cdi-2.0</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpConfig-1.3</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpRestClient-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpOpenTracing-1.1</artifactId>
+            <type>esa</type>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-        </dependency>
+        <!-- Java utility classes -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -237,7 +237,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://repo1.maven.org/maven2/net/wasdev/wlp/tracer/liberty-opentracing-zipkintracer/1.0/liberty-opentracing-zipkintracer-1.0-sample.zip</url>
+                            <url>${zipkin.usr.feature}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
                             <!-- <md5>/md5> -->

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -164,13 +164,12 @@
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <!-- <assemblyArtifact>
+                    <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-runtime</artifactId>
                         <version>${version.openliberty-runtime}</version>
                         <type>zip</type>
-                    </assemblyArtifact> -->
-                    <assemblyArchive>/Users/dima/Downloads/openliberty-all-18.0.0.3-20180822-1616.zip</assemblyArchive>
+                    </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <include>usr</include>
                     <bootstrapProperties>
@@ -225,6 +224,7 @@
             </plugin>
 
             <!-- For downloading files -->
+            <!-- tag::download[] -->
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
@@ -240,11 +240,11 @@
                             <url>${zipkin.usr.feature}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
-                            <!-- <md5>/md5> -->
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+            <!-- end::download[] -->
 
             <!-- Plugin to run unit tests -->
             <plugin>

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import org.eclipse.microprofile.opentracing.Traced;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
-import io.opentracing.ActiveSpan;
+import io.opentracing.Scope;
 import io.opentracing.Tracer;
 import io.openliberty.guides.inventory.model.*;
 
@@ -53,7 +53,7 @@ public class InventoryManager {
         if (!systems.contains(system)) {
             // tag::custom-tracer[]
             try (Scope childScope = tracer.buildSpan("add() Span")
-                                              .startActive()) {
+                                              .startActive(true)) {
                 // tag::addToInvList[]
                 systems.add(system);
                 // end::addToInvList[]

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -52,7 +52,7 @@ public class InventoryManager {
         SystemData system = new SystemData(hostname, props);
         if (!systems.contains(system)) {
             // tag::custom-tracer[]
-            try (ActiveSpan childSpan = tracer.buildSpan("add() Span")
+            try (Scope childScope = tracer.buildSpan("add() Span")
                                               .startActive()) {
                 // tag::addToInvList[]
                 systems.add(system);

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -6,7 +6,7 @@
     <feature>cdi-1.2</feature>
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
-    <feature>mpOpenTracing-1.0</feature>
+    <feature>mpOpenTracing-1.1</feature>
     <feature>usr:opentracingZipkin-0.30</feature>
   </featureManager>
 

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -6,8 +6,12 @@
     <feature>cdi-1.2</feature>
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
+    <!-- tag::mpOpenTracing[] -->
     <feature>mpOpenTracing-1.1</feature>
+    <!-- end::mpOpenTracing[] -->
+    <!-- tag::zipkinUsr[] -->
     <feature>usr:opentracingZipkin-0.31</feature>
+    <!-- end::zipkinUsr[] -->
   </featureManager>
 
   <opentracingZipkin host="localhost"/>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -7,7 +7,7 @@
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>mpOpenTracing-1.1</feature>
-    <feature>usr:opentracingZipkin-0.30</feature>
+    <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>
 
   <opentracingZipkin host="localhost"/>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -1,11 +1,11 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.0</feature>
-    <feature>jsonp-1.0</feature>
-    <feature>cdi-1.2</feature>
-    <feature>mpConfig-1.2</feature>
-    <feature>mpRestClient-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonp-1.1</feature>
+    <feature>cdi-2.0</feature>
+    <feature>mpConfig-1.3</feature>
+    <feature>mpRestClient-1.1</feature>
     <!-- tag::mpOpenTracing[] -->
     <feature>mpOpenTracing-1.1</feature>
     <!-- end::mpOpenTracing[] -->

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -24,7 +24,7 @@
         <inv.service.http.port>9081</inv.service.http.port>
         <inv.service.https.port>9444</inv.service.https.port>
         <!-- Zipkin user feature download link -->
-        <zipkin.usr.feature>REPLACE-WITH-VALID-LINK-LATER</zipkin.usr.feature>
+        <zipkin.usr.feature>https://github.com/WASdev/sample.opentracing.zipkintracer/releases/download/1.1/liberty-opentracing-zipkintracer-1.1-sample.zip</zipkin.usr.feature>
     </properties>
 
     <!-- Shared dependencies. -->

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -24,7 +24,7 @@
         <inv.service.http.port>9081</inv.service.http.port>
         <inv.service.https.port>9444</inv.service.https.port>
         <!-- Zipkin user feature download link -->
-        <zipkin.usr.feature>REPLACE_ME_WITH_VALID_LINK</zipkin.usr.feature>
+        <zipkin.usr.feature>REPLACE-WITH-VALID-LINK-LATER</zipkin.usr.feature>
     </properties>
 
     <!-- Shared dependencies. -->

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -31,6 +31,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- For tests -->
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -53,49 +61,6 @@
                 <artifactId>javax.json</artifactId>
                 <version>1.0.4</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.0.1</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.ibm.websphere.appserver.api</groupId>
-                <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-                <version>1.0.10</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.json</groupId>
-                <artifactId>javax.json-api</artifactId>
-                <version>1.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>1.2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing</groupId>
-                <artifactId>opentracing-api</artifactId>
-                <version>0.31.0</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.opentracing</groupId>
-                <artifactId>microprofile-opentracing-api</artifactId>
-                <version>1.1</version>
-                <scope>provided</scope>
-            </dependency>
-            <!-- for RestClient -->
-            <dependency>
-                <groupId>org.eclipse.microprofile.rest.client</groupId>
-                <artifactId>microprofile-rest-client-api</artifactId>
-                <version>1.0</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -23,6 +23,8 @@
         <sys.service.https.port>9443</sys.service.https.port>
         <inv.service.http.port>9081</inv.service.http.port>
         <inv.service.https.port>9444</inv.service.https.port>
+        <!-- Zipkin user feature download link -->
+        <zipkin.usr.feature>REPLACE_ME_WITH_VALID_LINK</zipkin.usr.feature>
     </properties>
 
     <!-- Shared dependencies. -->
@@ -79,13 +81,13 @@
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
-                <version>0.30.0</version>
+                <version>0.31.0</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.opentracing</groupId>
                 <artifactId>microprofile-opentracing-api</artifactId>
-                <version>1.0</version>
+                <version>1.1</version>
                 <scope>provided</scope>
             </dependency>
             <!-- for RestClient -->

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -152,7 +152,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://repo1.maven.org/maven2/net/wasdev/wlp/tracer/liberty-opentracing-zipkintracer/1.0/liberty-opentracing-zipkintracer-1.0-sample.zip</url>
+                            <url>${zipkin.usr.feature}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
                             <!-- <md5></md5> -->

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
 
     <dependencies>
+        <!-- For tests -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -28,29 +29,36 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
         </dependency>
+        <!-- Open Liberty features -->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>cdi-2.0</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpConfig-1.3</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpRestClient-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpOpenTracing-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <!-- JDK9+ -->
         <dependency>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -82,13 +82,12 @@
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <!-- <assemblyArtifact>
+                    <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-runtime</artifactId>
                         <version>${version.openliberty-runtime}</version>
                         <type>zip</type>
-                    </assemblyArtifact> -->
-                    <assemblyArchive>/Users/dima/Downloads/openliberty-all-18.0.0.3-20180822-1616.zip</assemblyArchive>
+                    </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <include>usr</include>
                     <bootstrapProperties>
@@ -155,7 +154,6 @@
                             <url>${zipkin.usr.feature}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
-                            <!-- <md5></md5> -->
                         </configuration>
                     </execution>
                 </executions>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -82,12 +82,13 @@
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <assemblyArtifact>
+                    <!-- <assemblyArtifact>
                         <groupId>io.openliberty</groupId>
                         <artifactId>openliberty-runtime</artifactId>
                         <version>${version.openliberty-runtime}</version>
                         <type>zip</type>
-                    </assemblyArtifact>
+                    </assemblyArtifact> -->
+                    <assemblyArchive>/Users/dima/Downloads/openliberty-all-18.0.0.3-20180822-1616.zip</assemblyArchive>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <include>usr</include>
                     <bootstrapProperties>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -6,7 +6,7 @@
     <feature>cdi-1.2</feature>
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
-    <feature>mpOpenTracing-1.0</feature>
+    <feature>mpOpenTracing-1.1</feature>
     <feature>usr:opentracingZipkin-0.30</feature>
   </featureManager>
 

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -1,11 +1,11 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.0</feature>
-    <feature>jsonp-1.0</feature>
-    <feature>cdi-1.2</feature>
-    <feature>mpConfig-1.2</feature>
-    <feature>mpRestClient-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonp-1.1</feature>
+    <feature>cdi-2.0</feature>
+    <feature>mpConfig-1.3</feature>
+    <feature>mpRestClient-1.1</feature>
     <feature>mpOpenTracing-1.1</feature>
     <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -7,7 +7,7 @@
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
     <feature>mpOpenTracing-1.1</feature>
-    <feature>usr:opentracingZipkin-0.30</feature>
+    <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>
 
   <opentracingZipkin host="localhost"/>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -64,7 +64,24 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-        </dependency>        
+        </dependency>
+        <!-- JDK9+ -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency> 
     </dependencies>
 
     <profiles>
@@ -207,6 +224,7 @@
             </plugin>
 
             <!-- For downloading files -->
+            <!-- tag::download[] -->
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
@@ -219,14 +237,14 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://repo1.maven.org/maven2/net/wasdev/wlp/tracer/liberty-opentracing-zipkintracer/1.0/liberty-opentracing-zipkintracer-1.0-sample.zip</url>
+                            <url>${zipkin.usr.feature}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
-                            <!-- <md5>/md5> -->
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+            <!-- end::download[] -->
 
             <!-- Plugin to run unit tests -->
             <plugin>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -17,6 +17,7 @@
     </properties>
 
     <dependencies>
+        <!-- For tests -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -33,34 +34,38 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
         </dependency>
+        <!-- Open Liberty features -->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>cdi-2.0</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpConfig-1.3</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpRestClient-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpOpenTracing-1.1</artifactId>
+            <type>esa</type>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-        </dependency>
+        <!-- Java utility classes -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import org.eclipse.microprofile.opentracing.Traced;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
-import io.opentracing.ActiveSpan;
+import io.opentracing.Scope;
 import io.opentracing.Tracer;
 import io.openliberty.guides.inventory.model.*;
 

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -6,8 +6,8 @@
     <feature>cdi-1.2</feature>
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
-    <feature>mpOpenTracing-1.0</feature>
-    <feature>usr:opentracingZipkin-0.30</feature>
+    <feature>mpOpenTracing-1.1</feature>
+    <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>
 
   <opentracingZipkin host="localhost"/>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -1,11 +1,11 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.0</feature>
-    <feature>jsonp-1.0</feature>
-    <feature>cdi-1.2</feature>
-    <feature>mpConfig-1.2</feature>
-    <feature>mpRestClient-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonp-1.1</feature>
+    <feature>cdi-2.0</feature>
+    <feature>mpConfig-1.3</feature>
+    <feature>mpRestClient-1.1</feature>
     <feature>mpOpenTracing-1.1</feature>
     <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -24,7 +24,7 @@
         <inv.service.http.port>9081</inv.service.http.port>
         <inv.service.https.port>9444</inv.service.https.port>
         <!-- Zipkin user feature download link -->
-        <zipkin.usr.feature>REPLACE-WITH-VALID-LINK-LATER</zipkin.usr.feature>
+        <zipkin.usr.feature>https://github.com/WASdev/sample.opentracing.zipkintracer/releases/download/1.1/liberty-opentracing-zipkintracer-1.1-sample.zip</zipkin.usr.feature>
     </properties>
 
     <!-- Shared dependencies. -->

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -23,6 +23,8 @@
         <sys.service.https.port>9443</sys.service.https.port>
         <inv.service.http.port>9081</inv.service.http.port>
         <inv.service.https.port>9444</inv.service.https.port>
+        <!-- Zipkin user feature download link -->
+        <zipkin.usr.feature>REPLACE-WITH-VALID-LINK-LATER</zipkin.usr.feature>
     </properties>
 
     <!-- Shared dependencies. -->
@@ -79,13 +81,13 @@
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
-                <version>0.30.0</version>
+                <version>0.31.0</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.opentracing</groupId>
                 <artifactId>microprofile-opentracing-api</artifactId>
-                <version>1.0</version>
+                <version>1.1</version>
                 <scope>provided</scope>
             </dependency>
             <!-- for RestClient -->

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -31,6 +31,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- For tests -->
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -53,49 +61,6 @@
                 <artifactId>javax.json</artifactId>
                 <version>1.0.4</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.0.1</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.ibm.websphere.appserver.api</groupId>
-                <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
-                <version>1.0.10</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.json</groupId>
-                <artifactId>javax.json-api</artifactId>
-                <version>1.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>1.2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.opentracing</groupId>
-                <artifactId>opentracing-api</artifactId>
-                <version>0.31.0</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.opentracing</groupId>
-                <artifactId>microprofile-opentracing-api</artifactId>
-                <version>1.1</version>
-                <scope>provided</scope>
-            </dependency>
-            <!-- for RestClient -->
-            <dependency>
-                <groupId>org.eclipse.microprofile.rest.client</groupId>
-                <artifactId>microprofile-rest-client-api</artifactId>
-                <version>1.0</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -52,6 +52,23 @@
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
         </dependency>
+        <!-- JDK9+ -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -134,10 +151,9 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://repo1.maven.org/maven2/net/wasdev/wlp/tracer/liberty-opentracing-zipkintracer/1.0/liberty-opentracing-zipkintracer-1.0-sample.zip</url>
+                            <url>${zipkin.usr.feature}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/liberty/wlp/usr</outputDirectory>
-                            <!-- <md5></md5> -->
                         </configuration>
                     </execution>
                 </executions>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
 
     <dependencies>
+        <!-- For tests -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -28,29 +29,36 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
         </dependency>
+        <!-- Open Liberty features -->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>com.ibm.websphere.appserver.api</groupId>
-            <artifactId>com.ibm.websphere.appserver.api.jaxrs20</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jsonp-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>cdi-2.0</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpConfig-1.3</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>io.opentracing</groupId>
-            <artifactId>opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpRestClient-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>mpOpenTracing-1.1</artifactId>
+            <type>esa</type>
         </dependency>
         <!-- JDK9+ -->
         <dependency>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -6,8 +6,8 @@
     <feature>cdi-1.2</feature>
     <feature>mpConfig-1.2</feature>
     <feature>mpRestClient-1.0</feature>
-    <feature>mpOpenTracing-1.0</feature>
-    <feature>usr:opentracingZipkin-0.30</feature>
+    <feature>mpOpenTracing-1.1</feature>
+    <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>
 
   <opentracingZipkin host="localhost"/>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -1,11 +1,11 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.0</feature>
-    <feature>jsonp-1.0</feature>
-    <feature>cdi-1.2</feature>
-    <feature>mpConfig-1.2</feature>
-    <feature>mpRestClient-1.0</feature>
+    <feature>jaxrs-2.1</feature>
+    <feature>jsonp-1.1</feature>
+    <feature>cdi-2.0</feature>
+    <feature>mpConfig-1.3</feature>
+    <feature>mpRestClient-1.1</feature>
     <feature>mpOpenTracing-1.1</feature>
     <feature>usr:opentracingZipkin-0.31</feature>
   </featureManager>


### PR DESCRIPTION
All updates need for mpOpenTracing-1.1 and opentracing-0.31.0 

**DO  NOT MERGE** until mpOpenTracing-1.1 is released as a part of 18.0.0.3 and when the zipkin user feature version 0.31.0 is available for download (https://github.com/fmhwong/sample.opentracing.zipkintracer/tree/9-opentracing_0.31).

Once ready for merging, update `finish/pom.xml` and `start/pom.xml` and replace `REPLACE-WITH-VALID-LINK-LATER` with the download link for the zipkin user feature 0.31.0. I've already tested everything locally, but it might be worth going over everything just in case.