### PR TITLE
Removed traceSpecification comment from server.xml

### DIFF
--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -16,8 +16,7 @@
 
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
-
-
+      
   <webApplication location="inventory-service.war" contextRoot="/">
     <!-- enable visibility to third party apis -->
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -17,7 +17,6 @@
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
 
-  <!-- <logging traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all"/> -->
 
   <webApplication location="inventory-service.war" contextRoot="/">
     <!-- enable visibility to third party apis -->

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -13,8 +13,6 @@
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
 
-  <!-- <logging traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all"/> -->
-
   <webApplication location="system-service.war" contextRoot="/">
     <!-- enable visibility to third party apis -->
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -13,7 +13,6 @@
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
 
-  <!-- <logging traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all"/> -->
 
   <webApplication location="inventory-service.war" contextRoot="/">
     <!-- enable visibility to third party apis -->

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -13,7 +13,6 @@
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
 
-
   <webApplication location="inventory-service.war" contextRoot="/">
     <!-- enable visibility to third party apis -->
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -13,8 +13,6 @@
   <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
       id="defaultHttpEndpoint" host="*" />
 
-  <!-- <logging traceSpecification="*=info:com.ibm.ws.opentracing*=all:com.ibm.ws.microprofile.opentracing*=all"/> -->
-
   <webApplication location="system-service.war" contextRoot="/">
     <!-- enable visibility to third party apis -->
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>


### PR DESCRIPTION
Issue: https://github.com/OpenLiberty/guide-microprofile-opentracing/issues/70
---

`<logging traceSpecification>` is not needed. 

This line is not mentioned in the guide content and won't affect the steps of the guide. 

The `<logging traceSpecification>` line is used to enable trace log messages that would only appear in a trace.log file, and would only be used for further debugging. Since the guide doesn't involve these extra debugging logs, the line should not be uncommented. Also, the comment does not need to be shown on the right pane. Guide was tested with the comment removed.

---
According to IBM Support:(https://www.ibm.com/support/knowledgecenter/en/SSZH4A_6.1.0/com.ibm.worklight.monitor.doc/monitor/c_configure_logging_dev_server.html)

![image](https://user-images.githubusercontent.com/46586499/58658039-9af33180-82ed-11e9-8ff8-123d7d170f1d.png)

According to open-liberty wiki:
(https://github.com/OpenLiberty/open-liberty/wiki/MicroProfile:-OpenTracing)

![image](https://user-images.githubusercontent.com/46586499/58657637-bc075280-82ec-11e9-9c0f-f51f7c010afd.png)

