### PR TITLE
update licensing year

### DIFF
--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
- update 2020 to 2018, 2020 as requested here: https://github.com/OpenLiberty/guide-microprofile-opentracing/pull/99